### PR TITLE
Implement /scars note viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,19 @@ python3 -m pip install --upgrade -r requirements.txt
 
 Create a `config.json` file in the project root after cloning. This configuration is loaded by both the Flask dashboard and the Discord logger. An example path would be `/opt/bonefire/config.json` when running the service.
 
+## Scars viewer
+
+The `/scars` endpoint in `bonefire_flask.py` displays user reports collected via the `/scar_the_ember` bot command. Access is granted according to Discord roles and the viewer name is shown as a watermark on the page.
+
+### scar_notes table
+
+Reports are stored in a table named `scar_notes` with the following columns:
+
+| column           | description                   |
+|------------------|-------------------------------|
+| `id`             | primary key                   |
+| `target_username`| user the note refers to       |
+| `content`        | text of the note              |
+| `added_by_name`  | reporter display name         |
+| `created_at`     | timestamp when note was added |
+

--- a/templates/scars.html
+++ b/templates/scars.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>특이사항 열람</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <style>
+    .watermark {
+      position: fixed;
+      bottom: 10px;
+      right: 10px;
+      color: rgba(100, 100, 100, 0.3);
+      font-size: 14px;
+      pointer-events: none;
+      z-index: 1000;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="watermark">조회자: {{ viewer_name }}</div>
+  <h2>특이사항 목록</h2>
+  <table>
+    <tr>
+      <th>대상</th>
+      <th>내용</th>
+      {% if show_reporter %}
+        <th>제보자</th>
+      {% endif %}
+    </tr>
+    {% for note in notes %}
+    <tr>
+      <td>{{ note.target_name }}</td>
+      <td>{{ note.description }}</td>
+      {% if show_reporter %}
+        <td>{{ note.added_by_name }}</td>
+      {% endif %}
+    </tr>
+    {% endfor %}
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add role-based access checker and `/scars` endpoint
- create HTML template for viewing scar notes with watermark
- document scar note table and endpoint in README

## Testing
- `python3 -m py_compile bonefire_flask.py bonefire_logger.py bonefire_tunnel.py`

------
https://chatgpt.com/codex/tasks/task_e_684629e4f7048324b5c1a002e2efaedf