### PR TITLE
Reduce JWT size for /scars link

### DIFF
--- a/bonefire_flask.py
+++ b/bonefire_flask.py
@@ -553,8 +553,15 @@ def view_scars():
 
     try:
         data = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
-        viewer_name = data.get("viewer", "Unknown")
-        member_roles = data.get("roles", [])
+        user_id = data.get("uid")
+        if not user_id:
+            return "<h3>유효하지 않은 토큰입니다.</h3>"
+        res = requests.get(f"{BOT_API_URL}/member_info/{user_id}")
+        info = res.json()
+        if not info.get("success"):
+            return "<h3>멤버 정보를 불러올 수 없습니다.</h3>"
+        viewer_name = info.get("display_name", "Unknown")
+        member_roles = info.get("roles", [])
         has_access, show_reporter = check_access_and_report_visibility(member_roles)
     except jwt.ExpiredSignatureError:
         return "<h3>토큰이 만료되었습니다.</h3>"

--- a/bonefire_logger.py
+++ b/bonefire_logger.py
@@ -146,8 +146,7 @@ def create_signed_link(member: discord.Member) -> str | None:
     if not url:
         return None
     payload = {
-        "viewer": member.display_name,
-        "roles": [r.name for r in member.roles],
+        "uid": str(member.id),
         "exp": int(time.time()) + 300,
     }
     token = jwt.encode(payload, JWT_SECRET, algorithm="HS256")
@@ -236,6 +235,25 @@ async def add_note(request: Request):
         data["added_by_name"],
     )
     return {"success": True}
+
+
+@app.get("/member_info/{user_id}")
+async def member_info(user_id: int):
+    """Return display name and role list for a Discord member."""
+    if bot.guild is None:
+        return {"success": False, "reason": "Bot not ready"}
+    member = bot.guild.get_member(user_id)
+    if member is None:
+        try:
+            member = await bot.fetch_member(user_id)
+        except Exception:
+            return {"success": False, "reason": "not_found"}
+
+    return {
+        "success": True,
+        "display_name": member.display_name,
+        "roles": [r.name for r in member.roles],
+    }
 
 # ---------- Discord Bot ----------
 class TrackingBot(discord.Client):


### PR DESCRIPTION
## Summary
- shorten JWT payload generated for `/scars`
- expose new `/member_info/{user_id}` API to resolve user details
- update `/scars` page to fetch user info via API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684633c4c1248324ad340fc763816bea