### PR TITLE
Support nickname field in scar notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Reports are stored in a table named `scar_notes` with the following columns:
 |------------------|-------------------------------|
 | `id`             | primary key                   |
 | `target_username`| user the note refers to       |
+| `target_nickname`| nickname at time of note      |
 | `content`        | text of the note              |
 | `added_by_name`  | reporter display name         |
 | `created_at`     | timestamp when note was added |

--- a/bonefire_flask.py
+++ b/bonefire_flask.py
@@ -577,7 +577,7 @@ def view_scars():
         with db.cursor() as cursor:
             cursor.execute(
                 """
-                SELECT target_username, content, added_by_name
+                SELECT target_username, target_nickname, content, added_by_name
                 FROM scar_notes
                 ORDER BY id DESC
                 """
@@ -586,8 +586,9 @@ def view_scars():
                 notes.append(
                     {
                         "target_name": row[0],
-                        "description": row[1],
-                        "added_by_name": row[2],
+                        "target_nick": row[1],
+                        "description": row[2],
+                        "added_by_name": row[3],
                     }
                 )
     finally:

--- a/bonefire_logger.py
+++ b/bonefire_logger.py
@@ -152,14 +152,28 @@ def create_signed_link(member: discord.Member) -> str | None:
     token = jwt.encode(payload, JWT_SECRET, algorithm="HS256")
     return f"{url}/scars?token={token}"
 
-def add_scar_note(target_user_id: str, target_username: str, content: str, added_by_id: str, added_by_name: str):
+def add_scar_note(
+    target_user_id: str,
+    target_username: str,
+    target_nickname: str | None,
+    content: str,
+    added_by_id: str,
+    added_by_name: str,
+):
     """Insert a scar note about a user into the database."""
     query_db(
         """
-        INSERT INTO scar_notes (target_user_id, target_username, added_by_id, added_by_name, content)
-        VALUES (%s, %s, %s, %s, %s)
+        INSERT INTO scar_notes (target_user_id, target_username, target_nickname, added_by_id, added_by_name, content)
+        VALUES (%s, %s, %s, %s, %s, %s)
         """,
-        (target_user_id, target_username, added_by_id, added_by_name, content),
+        (
+            target_user_id,
+            target_username,
+            target_nickname,
+            added_by_id,
+            added_by_name,
+            content,
+        ),
     )
 
 # ---------- FastAPI ----------
@@ -221,6 +235,7 @@ async def add_note(request: Request):
     required = [
         "target_user_id",
         "target_username",
+        "target_nickname",
         "content",
         "added_by_id",
         "added_by_name",
@@ -230,6 +245,7 @@ async def add_note(request: Request):
     add_scar_note(
         data["target_user_id"],
         data["target_username"],
+        data.get("target_nickname"),
         data["content"],
         data["added_by_id"],
         data["added_by_name"],
@@ -333,6 +349,7 @@ class TrackingBot(discord.Client):
             add_scar_note(
                 str(target_user.id),
                 target_user.name,
+                target_user.nick,
                 note,
                 str(member.id),
                 member.name,

--- a/templates/scars.html
+++ b/templates/scars.html
@@ -53,7 +53,13 @@
     </tr>
     {% for note in notes %}
     <tr>
-      <td>{{ note.target_name }}</td>
+      <td>
+        {% if note.target_nick %}
+          {{ note.target_name }} ({{ note.target_nick }})
+        {% else %}
+          {{ note.target_name }}
+        {% endif %}
+      </td>
       <td>{{ note.description }}</td>
       {% if show_reporter %}
         <td>{{ note.added_by_name }}</td>


### PR DESCRIPTION
## Summary
- log target nicknames in the scar_notes table
- expect target nicknames via `/notes` API
- include nicknames when using the scar slash command
- display nicknames in scars viewer
- document new `target_nickname` column

## Testing
- `python3 -m py_compile bonefire_logger.py bonefire_flask.py bonefire_tunnel.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463aceefe883248bd3b5e1bf0f08bf