### PR TITLE
Add watermark overlay across entire scars page

### DIFF
--- a/static/scars.css
+++ b/static/scars.css
@@ -29,19 +29,6 @@ header .time {
   color: #ccc;
 }
 
-.watermark {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 1000;
-  transform: rotate(-30deg);
-  background-repeat: repeat;
-  background-size: 260px 160px;
-  opacity: 0.15;
-}
 
 .note-list {
   display: flex;

--- a/templates/scars.html
+++ b/templates/scars.html
@@ -8,13 +8,24 @@
   {% set viewer_watermark = viewer_name %}
   {% set watermark_svg = "<svg xmlns='http://www.w3.org/2000/svg' width='260' height='160'><text x='0' y='120' font-size='20' fill='rgb(255,255,255)' font-family='Arial, sans-serif' opacity='0.15'>" ~ viewer_watermark ~ "</text></svg>" %}
   <style>
-    .watermark {
+    body::before {
+      content: "";
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: 1000;
+      transform: rotate(-30deg);
       background-image: url("data:image/svg+xml;utf8,{{ watermark_svg | urlencode }}");
+      background-repeat: repeat;
+      background-size: 260px 160px;
+      opacity: 0.15;
     }
   </style>
 </head>
 <body>
-  <div class="watermark"></div>
   <header>
     <h1>🔥 화톳불 - 특이사항 열람</h1>
     <div class="viewer">{{ viewer_name }}</div>


### PR DESCRIPTION
## Summary
- overlay repeating watermark directly on the page using a `body::before` style
- remove obsolete `.watermark` element and styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468aa34a088324be4cf0cf3d548843